### PR TITLE
Fix the load order issues of Sweeping module

### DIFF
--- a/lib/rails/observers/action_controller/caching.rb
+++ b/lib/rails/observers/action_controller/caching.rb
@@ -7,6 +7,6 @@ module ActionController #:nodoc:
       autoload :Sweeping, 'rails/observers/action_controller/caching/sweeping'
     end
 
-    include Sweeping if defined?(ActiveRecord)
+    ActionController::Base.extend Sweeping::ClassMethods if defined?(ActiveRecord)
   end
 end

--- a/lib/rails/observers/action_controller/caching/sweeping.rb
+++ b/lib/rails/observers/action_controller/caching/sweeping.rb
@@ -30,8 +30,6 @@ module ActionController #:nodoc:
     #     cache_sweeper OpenBar::Sweeper, :only => [ :edit, :destroy, :share ]
     #   end
     module Sweeping
-      extend ActiveSupport::Concern
-
       module ClassMethods #:nodoc:
         def cache_sweeper(*sweepers)
           configuration = sweepers.extract_options!


### PR DESCRIPTION
### WHAT

Remove `Concern` from the `Sweeping` module so we can directly extend it in `ActionController::Base`
### WHY

Basically this is what happens, in the context of `ActionController` when the app is booting:
1) `Base` loads and includes the `Caching` module
2) `rails-observers` railtie is [then triggered](https://github.com/rails/rails-observers/blob/25ad85c3029b8c78bb984b2c968e2b98bdcc2dff/lib/rails/observers/railtie.rb#L18]) to [include](https://github.com/rails/rails-observers/blob/25ad85c3029b8c78bb984b2c968e2b98bdcc2dff/lib/rails/observers/action_controller/caching.rb#L10)  `Caching::Sweeping` concern as a dependency of `Caching`, but it doesn't actually get included because `Caching` is a concern too.
3) However `Caching` was already included in step 1, so `Caching::Sweeping` never gets included in `Base` and people run into this error: https://github.com/rails/rails-observers/issues/4

Note: the tests for this were working before because it didn't use the railtie to load `Sweeping`. It just directly loaded the files with `Sweeping` in them before it loaded `ActionController::Base`.
### FIXES

https://github.com/rails/rails-observers/issues/4
