### PR TITLE
Fix Texts on Master

### DIFF
--- a/test/transaction_callbacks_test.rb
+++ b/test/transaction_callbacks_test.rb
@@ -244,35 +244,3 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
     assert_equal [:after_rollback], @second.history
   end
 end
-
-
-class SaveFromAfterCommitBlockTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
-
-  class TopicWithSaveInCallback < ActiveRecord::Base
-    self.table_name = :topics
-    after_commit :cache_topic, :on => :create
-    after_commit :call_update, :on => :update
-    attr_accessor :cached, :record_updated
-
-    def call_update
-      self.record_updated = true
-    end
-
-    def cache_topic
-      unless cached
-        self.cached = true
-        self.save
-      else
-        self.cached = false
-      end
-    end
-  end
-
-  def test_after_commit_in_save
-    topic = TopicWithSaveInCallback.new()
-    topic.save
-    assert_equal true, topic.cached
-    assert_equal true, topic.record_updated
-  end
-end


### PR DESCRIPTION
Remove after_commit since was removed on https://github.com/rails/rails/commit/9d2146ac6e4c1fdc9cc157d614b1eb9968ac6a2e
