### PR TITLE
Add license to gemspec.erb

### DIFF
--- a/rails-observers.gemspec.erb
+++ b/rails-observers.gemspec.erb
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{ActiveModel::Observer, ActiveRecord::Observer and ActionController::Caching::Sweeper extracted from Rails.}
   s.homepage    = "https://github.com/rails/rails-observers"
   s.version     = Rails::Observers::VERSION
+  s.license     = 'MIT'
 
   s.files         = [<%= files.map(&:inspect).join ',' %>]
   s.test_files    = [<%= test_files.map(&:inspect).join ',' %>]


### PR DESCRIPTION
Issue #12 requested the License be added to `rails-observers.gemspec`, but it seems as though a Rake task is responsible for generating that gemspec automatically through this file. Therefore, the ERB gemspec should include the license.
