### PR TITLE
Load all observers from app/models before config initialization.

### DIFF
--- a/lib/rails/observers/railtie.rb
+++ b/lib/rails/observers/railtie.rb
@@ -19,6 +19,15 @@ module Rails
         end
       end
 
+      config.before_initialize do |app|
+        Dir.glob(File.join([Rails.root, "app", "models", "*_observer.rb"])).each do |observer_file|
+          observer_name = File.basename(observer_file, ".rb")
+          if observer_name.length > 0
+            app.config.active_record.observers = observer_name.to_sym
+          end
+        end
+      end
+
       config.after_initialize do |app|
         ActiveSupport.on_load(:active_record) do
           ActiveRecord::Base.instantiate_observers

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -14,11 +14,7 @@ class ConfigurationTest < ActiveSupport::TestCase
     teardown_app
   end
 
-  test "config.active_record.observers" do
-    add_to_config <<-RUBY
-      config.active_record.observers = :foo_observer
-    RUBY
-
+  test "autoload observers before rails config initialization" do
     app_file 'app/models/foo.rb', <<-RUBY
       class Foo < ActiveRecord::Base
       end


### PR DESCRIPTION
This patch contains some logic of loading all `*_observer.rb` files from app/models. It's uncomfortable to define the observers one by one in the application config, rails-observer should find and load the observer files by default.
