### PR TITLE
fixing tests

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require 'active_record'
-
+require 'rails'
 require 'rails/observers/activerecord/active_record'
 
 FIXTURES_ROOT = File.expand_path(File.dirname(__FILE__)) + "/fixtures"
@@ -67,8 +67,4 @@ class Developer < ActiveRecord::Base
 end
 
 class Minimalistic < ActiveRecord::Base
-end
-
-ActiveSupport::Deprecation.silence do
-  require 'active_record/test_case'
 end

--- a/test/lifecycle_test.rb
+++ b/test/lifecycle_test.rb
@@ -118,7 +118,7 @@ class AroundTopicObserver < ActiveRecord::Observer
   end
 end
 
-class LifecycleTest < ActiveRecord::TestCase
+class LifecycleTest < ActiveSupport::TestCase
   fixtures :topics, :developers, :minimalistics
 
   def test_before_destroy

--- a/test/observing_test.rb
+++ b/test/observing_test.rb
@@ -32,6 +32,16 @@ end
 class ObservingTest < ActiveModel::TestCase
   def setup
     ObservedModel.observers.clear
+    FooObserver.singleton_class.instance_eval do
+      alias_method :original_observed_classes, :observed_classes
+    end
+  end
+
+  def teardown
+    FooObserver.singleton_class.instance_eval do
+      undef_method :observed_classes
+      alias_method :observed_classes, :original_observed_classes
+    end
   end
 
   test "initializes model with no cached observers" do

--- a/test/transaction_callbacks_test.rb
+++ b/test/transaction_callbacks_test.rb
@@ -1,6 +1,6 @@
 require "helper"
 
-class TransactionCallbacksTest < ActiveRecord::TestCase
+class TransactionCallbacksTest < ActiveSupport::TestCase
   self.use_transactional_fixtures = false
   fixtures :topics
 


### PR DESCRIPTION
- substituting ActiveRecord::TestCase with ActiveSupport::TestCase as ActiveRecord::TestCase is not public any more in rails 4.1
- restore `:observed_class` method in `ObservingTest` as it affects the `ObserverTest` otherwise
