### PR TITLE
An alternative solution for PR #39.

### DIFF
--- a/lib/rails/observers/railtie.rb
+++ b/lib/rails/observers/railtie.rb
@@ -27,11 +27,7 @@ module Rails
 
       config.after_initialize do |app|
         ActiveSupport.on_load(:active_record) do
-          # Rails 5.1 forward-compat. AD::R is deprecated to AS::R in Rails 5.
-          reloader = defined?(ActiveSupport::Reloader) ? ActiveSupport::Reloader : ActionDispatch::Reloader
-          reloader.to_prepare do
-            ActiveRecord::Base.instantiate_observers
-          end
+          ActiveRecord::Base.instantiate_observers
         end
 
         ActiveSupport.on_load(:active_resource) do


### PR DESCRIPTION
This is a simpler solution for PR #39 that works for our Rails app.  The problem with PR #41 is that it reloads observers every time a class is inherited. At least in our app, that completely breaks the Rails class loading mechanism as each class is loaded over and over and over.
