### PR TITLE
Make DB configuration compatilble with RoR 5.1.

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -30,7 +30,7 @@ if ActiveRecord::Base.respond_to?(:raise_in_transactional_callbacks=) && Rails.v
   ActiveRecord::Base.raise_in_transactional_callbacks = true
 end
 
-ActiveRecord::Base.configurations = { "test" => { adapter: 'sqlite3', database: ':memory:' } }
+ActiveRecord::Base.configurations = { 'test' => { 'adapter' => 'sqlite3', 'database' => ':memory:' } }
 ActiveRecord::Base.establish_connection(:test)
 
 ActiveRecord::Schema.verbose = false


### PR DESCRIPTION
The configuration does not accept symbols as a keys anymore, since
https://github.com/rails/rails/commit/0a4f60090ba6a61a2610d8a0c163cc97e8c95833,
so the keys has to be strings.

Alternatively, HashWithIndiferentAccess could be used instead of plain
Hash.

However, it is not clear if this RoR change was intentional.