### PR TITLE
Replace ActiveModel::TestCase with ActiveSupport::TestCase

### DIFF
--- a/test/observer_array_test.rb
+++ b/test/observer_array_test.rb
@@ -3,7 +3,7 @@ require 'active_model'
 require 'rails/observers/active_model/active_model'
 require 'models/observers'
 
-class ObserverArrayTest < ActiveModel::TestCase
+class ObserverArrayTest < ActiveSupport::TestCase
   def teardown
     ORM.observers.enable :all
     Budget.observers.enable :all

--- a/test/observing_test.rb
+++ b/test/observing_test.rb
@@ -29,7 +29,7 @@ class Foo
   include ActiveModel::Observing
 end
 
-class ObservingTest < ActiveModel::TestCase
+class ObservingTest < ActiveSupport::TestCase
   def setup
     ObservedModel.observers.clear
     FooObserver.singleton_class.instance_eval do
@@ -104,7 +104,7 @@ class ObservingTest < ActiveModel::TestCase
   end
 end
 
-class ObserverTest < ActiveModel::TestCase
+class ObserverTest < ActiveSupport::TestCase
   def setup
     ObservedModel.observers = :foo_observer
     FooObserver.singleton_class.instance_eval do


### PR DESCRIPTION
ActiveModel::TestCase was removed in Rails 5.1 (rails/rails/pull/27928).