### PR TITLE
Require helper to make Rails.version_matches? available.

### DIFF
--- a/test/sweeper_test.rb
+++ b/test/sweeper_test.rb
@@ -1,6 +1,5 @@
-require 'minitest/autorun'
+require 'helper'
 require 'action_controller'
-require 'active_record'
 require 'rails/observers/activerecord/active_record'
 require 'rails/observers/action_controller/caching'
 


### PR DESCRIPTION
Rails.version_matches? is used in this file.