### PR TITLE
ActionControlle::TestRequest now have to reference controller class.

### DIFF
--- a/test/sweeper_test.rb
+++ b/test/sweeper_test.rb
@@ -80,7 +80,11 @@ class SweeperTest < ActionController::TestCase
   def test_process(controller, action = "show")
     @controller = controller.is_a?(Class) ? controller.new : controller
     if ActionController::TestRequest.respond_to?(:create)
-      @request    = ActionController::TestRequest.create
+      if ActionController::TestRequest.method(:create).arity == 0
+        @request    = ActionController::TestRequest.create
+      else
+        @request    = ActionController::TestRequest.create @controller.class
+      end
     else
       @request    = ActionController::TestRequest.new
     end


### PR DESCRIPTION
This is required since https://github.com/rails/rails/pull/26092