### PR TITLE
Add after_*_commit callbacks

### DIFF
--- a/lib/rails/observers/active_resource/observing.rb
+++ b/lib/rails/observers/active_resource/observing.rb
@@ -10,6 +10,7 @@ module ActiveResource
       notify_observers(:before_create)
       if result = super
         notify_observers(:after_create)
+        notify_observers(:after_create_commit)
       end
       result
     end
@@ -26,6 +27,7 @@ module ActiveResource
       notify_observers(:before_update)
       if result = super
         notify_observers(:after_update)
+        notify_observers(:after_update_commit)
       end
       result
     end
@@ -34,6 +36,7 @@ module ActiveResource
       notify_observers(:before_destroy)
       if result = super
         notify_observers(:after_destroy)
+        notify_observers(:after_destroy_commit)
       end
       result
     end

--- a/lib/rails/observers/activerecord/observer.rb
+++ b/lib/rails/observers/activerecord/observer.rb
@@ -110,7 +110,14 @@ module ActiveRecord
         observer = self
         observer_name = observer.class.name.underscore.gsub('/', '__')
 
-        ActiveRecord::Callbacks::CALLBACKS.each do |callback|
+        callbacks = [
+          *ActiveRecord::Callbacks::CALLBACKS,
+          :after_create_commit,
+          :after_update_commit,
+          :after_destroy_commit
+        ]
+
+        callbacks.each do |callback|
           next unless respond_to?(callback)
           callback_meth = :"_notify_#{observer_name}_for_#{callback}"
           unless klass.respond_to?(callback_meth)

--- a/test/active_resource_observer_test.rb
+++ b/test/active_resource_observer_test.rb
@@ -61,9 +61,9 @@ class ActiveResourceObservingTest < ActiveSupport::TestCase
     Person.create(:name => 'Rick')
 
     if Rails.version.starts_with? '4.2'
-      assert_equal [:before_save, :before_create, :after_create, :after_create_commit, :after_save], self.history
-    else
       assert_equal [:before_save, :before_create, :after_create, :after_save], self.history
+    else
+      assert_equal [:before_save, :before_create, :after_create, :after_create_commit, :after_save], self.history
     end
   end
 

--- a/test/active_resource_observer_test.rb
+++ b/test/active_resource_observer_test.rb
@@ -16,9 +16,22 @@ class ActiveResourceObservingTest < ActiveSupport::TestCase
   class PersonObserver < ActiveModel::Observer
     observe :person
 
-    %w( after_create after_destroy after_save after_update
-        before_create before_destroy before_save before_update).each do |method|
-          define_method(method) { |*| log method }
+    callbacks = [
+      :after_create,
+      :after_create_commit,
+      :after_destroy,
+      :after_destroy_commit,
+      :after_save,
+      :after_update,
+      :after_update_commit,
+      :before_create,
+      :before_destroy,
+      :before_save,
+      :before_update
+    ]
+
+    callbacks.each do |method|
+      define_method(method) { |*| log method }
     end
 
     private
@@ -46,18 +59,18 @@ class ActiveResourceObservingTest < ActiveSupport::TestCase
 
   def test_create_fires_save_and_create_notifications
     Person.create(:name => 'Rick')
-    assert_equal [:before_save, :before_create, :after_create, :after_save], self.history
+    assert_equal [:before_save, :before_create, :after_create, :after_create_commit, :after_save], self.history
   end
 
   def test_update_fires_save_and_update_notifications
     person = Person.find(1)
     person.save
-    assert_equal [:before_save, :before_update, :after_update, :after_save], self.history
+    assert_equal [:before_save, :before_update, :after_update, :after_update_commit, :after_save], self.history
   end
 
   def test_destroy_fires_destroy_notifications
     person = Person.find(1)
     person.destroy
-    assert_equal [:before_destroy, :after_destroy], self.history
+    assert_equal [:before_destroy, :after_destroy, :after_destroy_commit], self.history
   end
 end

--- a/test/active_resource_observer_test.rb
+++ b/test/active_resource_observer_test.rb
@@ -59,18 +59,33 @@ class ActiveResourceObservingTest < ActiveSupport::TestCase
 
   def test_create_fires_save_and_create_notifications
     Person.create(:name => 'Rick')
-    assert_equal [:before_save, :before_create, :after_create, :after_create_commit, :after_save], self.history
+
+    if Rails.version.starts_with? '4.2'
+      assert_equal [:before_save, :before_create, :after_create, :after_create_commit, :after_save], self.history
+    else
+      assert_equal [:before_save, :before_create, :after_create, :after_save], self.history
+    end
   end
 
   def test_update_fires_save_and_update_notifications
     person = Person.find(1)
     person.save
-    assert_equal [:before_save, :before_update, :after_update, :after_update_commit, :after_save], self.history
+
+    if Rails.version.starts_with? '4.2'
+      assert_equal [:before_save, :before_update, :after_update, :after_save], self.history
+    else
+      assert_equal [:before_save, :before_update, :after_update, :after_update_commit, :after_save], self.history
+    end
   end
 
   def test_destroy_fires_destroy_notifications
     person = Person.find(1)
     person.destroy
-    assert_equal [:before_destroy, :after_destroy, :after_destroy_commit], self.history
+
+    if Rails.version.starts_with? '4.2'
+      assert_equal [:before_destroy, :after_destroy], self.history
+    else
+      assert_equal [:before_destroy, :after_destroy, :after_destroy_commit], self.history
+    end
   end
 end


### PR DESCRIPTION
This pull request adds supports for the following ActiveRecord callbacks:

* `after_create_commit`
* `after_update_commit`
* `after_destroy_commit`

I believe the callbacks to be sufficiently tested.