### PR TITLE
Only require active_record/base if ActiveRecord defined

### DIFF
--- a/lib/rails/observers/railtie.rb
+++ b/lib/rails/observers/railtie.rb
@@ -34,8 +34,7 @@ module Rails
           # which calls `instantiate_observers` to instantiate a `UserObserver`
           # which eventually calls `observed_class` thus constantizing `"User"`,
           # the class we're loading. 💣💥
-          require "active_record"
-          require "active_record/base"
+          require "active_record/base" if defined?(ActiveRecord)
         rescue LoadError
         end
 


### PR DESCRIPTION
Apologies for the immediate second PR.

My use case is a Rails app which uses Mongoid. Rails pulls in the `activerecord` gem as a dependency but it wasn't `require`d anywhere - until now. This means that `ActiveSupport.on_load(:active_record)` hooks will start getting invoked, causing an `ActiveRecord::ConnectionNotEstablished` from another dependency (https://github.com/RubyMoney/money-rails/blob/master/lib/money-rails/hooks.rb#L7 specifically).

Thoughts on this approach?