### PR TITLE
Make ActionController::Caching::Sweeper class thread safe

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in active_record-observers.gemspec
 gemspec
+gem "minitest", "~> 5.8.4"
 gem 'rails', github: 'rails/rails', branch: '5-1-stable'
 gem 'activeresource', github: 'rails/activeresource'
 

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "mocha", require: false
+gem "minitest", "~> 5.8.4"
 gem "rails", "~> 4.2.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 # Specify your gem"s dependencies in active_record-observers.gemspec
 gem "rails", github: "rails/rails", branch: "5-0-stable"
+gem "minitest", "~> 5.8.4"
 gem "activeresource", github: "rails/activeresource"
 
 gem "mocha", require: false

--- a/gemfiles/rails_master.gemfile
+++ b/gemfiles/rails_master.gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 # Specify your gem"s dependencies in active_record-observers.gemspec
 gem "rails", github: "rails/rails"
+gem "minitest", "~> 5.8.4"
 gem "activeresource", github: "rails/activeresource"
 
 gem "mocha", require: false

--- a/lib/rails/observers/action_controller/caching/sweeper.rb
+++ b/lib/rails/observers/action_controller/caching/sweeper.rb
@@ -63,7 +63,6 @@ module ActionController #:nodoc:
         controller.__send__(method, *arguments, &block)
       end
 
-      # @see https://robots.thoughtbot.com/always-define-respond-to-missing-when-overriding
       def respond_to_missing?(method, include_private = false)
         (controller.present? && controller.respond_to?(method)) || super
       end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,5 @@
 require 'minitest/autorun'
-require 'mocha/minitest'
+require 'mocha/mini_test'
 require 'active_record'
 require 'rails'
 require 'rails/observers/activerecord/active_record'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,5 @@
 require 'minitest/autorun'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 require 'active_record'
 require 'rails'
 require 'rails/observers/activerecord/active_record'


### PR DESCRIPTION
The current implementation of `ActionController::Caching::Sweeper` is not Thread safe and it may cause issues in multi-thread environments. The problem is that `@controller` variable is lost in the different Threads. For sweepers with big loops, it might cause the following error:

```
undefined method `expire_action' for #<ReleaseSweeper:0x000000073b69b8 @_routes=nil, @controller=nil>
```

## Changes

* Store the controller variable in a current Thread property
* Fix a deprecation message with minitest

This closes #71 