### PR TITLE
Fixes AR saving when around_* observer is disabled.

### DIFF
--- a/lib/rails/observers/active_model/observing.rb
+++ b/lib/rails/observers/active_model/observing.rb
@@ -348,7 +348,9 @@ module ActiveModel
     # Send observed_method(object) if the method exists and
     # the observer is enabled for the given object's class.
     def update(observed_method, object, *extra_args, &block) #:nodoc:
-      return if !respond_to?(observed_method) || disabled_for?(object)
+      if !respond_to?(observed_method) || disabled_for?(object)
+        return block && block.call
+      end
       send(observed_method, object, *extra_args, &block)
     end
 

--- a/test/lifecycle_test.rb
+++ b/test/lifecycle_test.rb
@@ -231,6 +231,17 @@ class LifecycleTest < ActiveSupport::TestCase
     assert_not_nil observer.topic_ids.last
   end
 
+  test "disabling around filter does not impact ActiveRecord saving" do
+    observer = AroundTopicObserver.instance
+    observer.topic_ids.clear
+    ActiveRecord::Base.observers.disable AroundTopicObserver do
+      topic = AroundTopic.new
+      topic.save
+      assert_not_nil topic.id
+    end
+    assert_empty observer.topic_ids
+  end
+
   test "able to disable observers" do
     observer = DeveloperObserver.instance # activate
     observer.calls.clear


### PR DESCRIPTION
Bug: disabling an observer that observes any of ```around_*``` filters, will prevent observable ActiveRecord model from saving.

Solution: when ```disabled_for?(object)``` is true we need to invoke provided ```&block``` so that actual saving can happen.