### PR TITLE
Add after_{create,update,delete}_commit callbacks to observers

### DIFF
--- a/lib/rails/observers/activerecord/observer.rb
+++ b/lib/rails/observers/activerecord/observer.rb
@@ -94,6 +94,12 @@ module ActiveRecord
   #
   class Observer < ActiveModel::Observer
 
+    CALLBACKS = ActiveRecord::Callbacks::CALLBACKS.dup
+
+    if Rails.version >= '5'
+      CALLBACKS.push(:after_create_commit, :after_update_commit, :after_destroy_commit)
+    end
+
     protected
 
       def observed_classes
@@ -110,7 +116,7 @@ module ActiveRecord
         observer = self
         observer_name = observer.class.name.underscore.gsub('/', '__')
 
-        ActiveRecord::Callbacks::CALLBACKS.each do |callback|
+        CALLBACKS.each do |callback|
           next unless respond_to?(callback)
           callback_meth = :"_notify_#{observer_name}_for_#{callback}"
           unless klass.respond_to?(callback_meth)

--- a/test/active_record_observer_test.rb
+++ b/test/active_record_observer_test.rb
@@ -1,0 +1,15 @@
+require 'minitest/autorun'
+require 'active_record'
+require 'rails/version'
+require 'rails/observers/active_model/observing'
+require 'rails/observers/activerecord/observer'
+
+class ActiveRecordObservingTest < ActiveSupport::TestCase
+  def test_observers_have_correct_callbacks
+    expected_callbacks = ActiveRecord::Callbacks::CALLBACKS.dup
+    if Rails.version >= '5'
+      expected_callbacks.push(:after_create_commit, :after_update_commit, :after_destroy_commit)
+    end
+    assert_equal expected_callbacks, ActiveRecord::Observer::CALLBACKS
+  end
+end


### PR DESCRIPTION
Rails 5 adds `after_{create,update,delete}_commit` callback aliases. See:
https://blog.bigbinary.com/2016/05/11/rails-5-adds-after_create-aliases.html

This PR makes these callbacks available in observers. Includes tests to verify the callbacks were added properly. This also maintains backwards compatibility with Rails 4.